### PR TITLE
Replace caniuse-api with caniuse-lite and add UA-based support checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,11 @@
         "@shoelace-style/shoelace": "^2.14.0",
         "@vitejs/plugin-legacy": "^5.3.0",
         "babel": "^6.23.0",
-        "caniuse-api": "^3.0.0",
+        "caniuse-lite": "^1.0.30001765",
         "core-js": "^3.36.0",
         "postcss-load-config": "^5.0.3"
       },
       "devDependencies": {
-        "@types/caniuse-api": "^3.0.6",
         "@types/node": "^20.11.19",
         "postcss": "^8.4.35",
         "postcss-preset-env": "^9.3.0",
@@ -3205,12 +3204,6 @@
         "url": "https://github.com/sponsors/claviska"
       }
     },
-    "node_modules/@types/caniuse-api": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/caniuse-api/-/caniuse-api-3.0.6.tgz",
-      "integrity": "sha512-yMGwHJaqwIEXc3x7EyY3CeS73QG9WeC00w2nZ0/inoRv9DiLIhfvrY6vmXMSKlpRLFxrLcAWJh3JTwYNPl3ihg==",
-      "dev": true
-    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -3456,21 +3449,10 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "peer": true
     },
-    "node_modules/caniuse-api": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
-      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-lite": "^1.0.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
-      }
-    },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001588",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001588.tgz",
-      "integrity": "sha512-+hVY9jE44uKLkH0SrUTqxjxqNTOWHsbnQDIKjwkZ3lNTzUUVdBLBGXtj/q5Mp5u98r3droaZAewQuEDzjQdZlQ==",
+      "version": "1.0.30001765",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz",
+      "integrity": "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3484,7 +3466,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -4007,16 +3990,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="
-    },
-    "node_modules/lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@types/caniuse-api": "^3.0.6",
     "@types/node": "^20.11.19",
     "postcss": "^8.4.35",
     "postcss-preset-env": "^9.3.0",
@@ -25,7 +24,7 @@
     "@shoelace-style/shoelace": "^2.14.0",
     "@vitejs/plugin-legacy": "^5.3.0",
     "babel": "^6.23.0",
-    "caniuse-api": "^3.0.0",
+    "caniuse-lite": "^1.0.30001765",
     "core-js": "^3.36.0",
     "postcss-load-config": "^5.0.3"
   }

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -1,37 +1,143 @@
 import '../scss/index.scss';
 import { tests } from './tests';
-import caniuse from 'caniuse-api';
+import { agents, feature, features } from 'caniuse-lite/dist/unpacker';
 
-const getBrowserName = () => {
-    let browserInfo = navigator.userAgent;
-    let browser;
-    if (browserInfo.includes('Opera') || browserInfo.includes('Opr')) {
-      browser = 'opera';
-    } else if (browserInfo.includes('Edg')) {
-      browser = 'edge';
-    } else if (browserInfo.includes('Chrome')) {
-      browser = 'chrome';
-    } else if (browserInfo.includes('Safari')) {
-      browser = 'safari';
-    } else if (browserInfo.includes('Firefox')) {
-      browser = 'firefox'
-    } else {
-      browser = 'unknown'
+type BrowserId = 'chrome' | 'firefox' | 'safari' | 'edge' | 'opera' | 'unknown';
+type SupportStatus = 'full' | 'partial' | 'none';
+
+const parseVersionNumber = (value?: string) => {
+    if (!value) {
+        return 0;
     }
-      return browser;
+    const parsed = Number.parseFloat(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const parseUserAgent = (userAgent: string) => {
+    let match: RegExpMatchArray | null = null;
+    let browserId: BrowserId = 'unknown';
+
+    if ((match = userAgent.match(/Edg\/([\d.]+)/))) {
+        browserId = 'edge';
+    } else if ((match = userAgent.match(/OPR\/([\d.]+)/))) {
+        browserId = 'opera';
+    } else if ((match = userAgent.match(/Chrome\/([\d.]+)/))) {
+        browserId = 'chrome';
+    } else if ((match = userAgent.match(/Firefox\/([\d.]+)/))) {
+        browserId = 'firefox';
+    } else if ((match = userAgent.match(/Version\/([\d.]+).*Safari/))) {
+        browserId = 'safari';
+    }
+
+    return {
+        browserId,
+        version: parseVersionNumber(match?.[1]),
+    };
+};
+
+const getLatestStableVersion = (browserId: BrowserId) => {
+    if (browserId === 'unknown') {
+        return null;
+    }
+
+    const agentData = agents[browserId];
+    if (!agentData) {
+        return null;
+    }
+
+    const releaseDates = agentData.release_date ?? {};
+    const latestRelease = Object.entries(releaseDates).reduce(
+        (latest, [version, releaseDate]) => {
+            if (releaseDate > latest.releaseDate) {
+                return { version, releaseDate };
+            }
+            return latest;
+        },
+        { version: '', releaseDate: 0 },
+    );
+
+    if (latestRelease.version) {
+        return latestRelease.version;
+    }
+
+    const versions = agentData.versions?.filter((entry) => entry) ?? [];
+    return versions.length > 0 ? versions[versions.length - 1] : null;
+};
+
+const getClosestVersionKey = (stats: Record<string, string>, version: number) => {
+    const versionKeys = Object.keys(stats)
+        .map((key) => ({ key, value: Number.parseFloat(key) }))
+        .filter((entry) => !Number.isNaN(entry.value))
+        .sort((a, b) => a.value - b.value);
+
+    if (versionKeys.length === 0) {
+        return null;
+    }
+
+    const match = versionKeys.filter((entry) => entry.value <= version);
+    return (match.length > 0 ? match[match.length - 1] : versionKeys[0]).key;
+};
+
+const getSupportStatus = (supportText: string): SupportStatus => {
+    const flag = supportText.trim().charAt(0);
+    if (flag === 'y') {
+        return 'full';
+    }
+    if (flag === 'a') {
+        return 'partial';
+    }
+    return 'none';
+};
+
+const getSupportMessage = (featureKey: string, browserId: BrowserId, version: number) => {
+    if (browserId === 'unknown') {
+        return { status: 'none', message: 'Caniuse: Browser not detected.' };
+    }
+
+    const packedFeature = features[featureKey];
+    if (!packedFeature) {
+        return {
+            status: 'none',
+            message: `Caniuse: No data available for "${featureKey}".`,
+        };
+    }
+
+    const unpackedFeature = feature(packedFeature);
+    const browserStats = unpackedFeature.stats[browserId];
+    if (!browserStats) {
+        return {
+            status: 'none',
+            message: `Caniuse: No support data for ${browserId}.`,
+        };
+    }
+
+    const versionKey = getClosestVersionKey(browserStats, version);
+    if (!versionKey) {
+        return {
+            status: 'none',
+            message: `Caniuse: No version data for ${browserId}.`,
+        };
+    }
+
+    const supportText = browserStats[versionKey];
+    const status = getSupportStatus(supportText);
+    const statusLabel =
+        status === 'full' ? 'Full support' : status === 'partial' ? 'Partial support' : 'No support';
+
+    return {
+        status,
+        message: `Caniuse: ${statusLabel} for ${browserId} ${versionKey} (${featureKey}).`,
+    };
+};
+
+const userAgent = navigator.userAgent;
+const { browserId, version } = parseUserAgent(userAgent);
+document.getElementById('useragent')!.innerHTML = userAgent;
+const latestStableVersion = getLatestStableVersion(browserId);
+const browserNameElement = document.getElementById('latestBrowser');
+if (browserNameElement) {
+    browserNameElement.innerHTML = latestStableVersion ?? 'Unknown';
 }
-
-var useragent = navigator.userAgent;
-document.getElementById('useragent')!.innerHTML = useragent;
-var latestStableBrowsers = caniuse.getLatestStableBrowsers();
-(latestStableBrowsers).forEach((browser) => {
-    // var browserName = browser.split(' ')[0];
-    var browserVersion = browser.split(' ')[1];
-    var browserNameElement = document.getElementById("latestBrowser");
-    if (browserNameElement) {
-        browserNameElement.innerHTML = browserVersion;
-    }
-});
 
 
 
@@ -65,7 +171,11 @@ tests.forEach((test) => {
             element.classList.add('unknown');
         }
 
-        element.innerHTML = `${test.name} - ${result_text[1]}`;
+        const caniuseComparison = test.caniuseFeature
+            ? getSupportMessage(test.caniuseFeature, browserId, version)
+            : { status: 'none', message: 'Caniuse: No feature mapping available.' };
+
+        element.innerHTML = `${test.name} - ${result_text[1]}<br /><small>${caniuseComparison.message}</small>`;
 
         document.querySelector('.tests')!.appendChild(element);
     })

--- a/src/ts/tests.ts
+++ b/src/ts/tests.ts
@@ -13,11 +13,13 @@ const tests = [
         name: "Cookies",
         test: "/tests/cookies.js",
         points: 50,
+        caniuseFeature: "cookie-store-api",
     },
     {
         name: "BigInt",
         test: "/tests/bigint.js",
         points: 50,
+        caniuseFeature: "bigint",
     }
 ]
 


### PR DESCRIPTION
### Motivation
- Remove the non-browser-safe `caniuse-api` dependency and use `caniuse-lite` unpacker data so feature data can be read directly in the browser bundle. 
- Detect the current browser and version from `navigator.userAgent` to provide targeted compatibility information instead of listing all browsers. 
- Surface per-test compatibility guidance alongside functional runtime tests so the UI shows both observed results and caniuse-based support hints.

### Description
- Replaced `import caniuse from 'caniuse-api';` with `import { agents, feature, features } from 'caniuse-lite/dist/unpacker'` and removed the `caniuse-api` type package. 
- Added a browser/version parser `parseUserAgent` and `parseVersionNumber` that produces canonical `browserId` values (`chrome`, `firefox`, `safari`, `edge`, `opera`) and a numeric version. 
- Implemented helpers `getLatestStableVersion`, `getClosestVersionKey`, `getSupportStatus`, and `getSupportMessage` to map a caniuse feature key and detected browser/version to a support classification and human-readable message. 
- Updated the UI behavior to display the latest stable version for the detected browser only and appended per-test comparison output to each test item, and added `caniuseFeature` keys to `src/ts/tests.ts`. 
- Updated `package.json` to remove `caniuse-api` and `@types/caniuse-api` and add `caniuse-lite`.

### Testing
- Launched the dev server with `npm run dev` to verify the app bundles and serves, which started successfully. 
- Captured a screenshot of the running app using a Playwright script against `http://127.0.0.1:4173/`, which completed and produced `artifacts/browser-support.png`. 
- Performed `npm remove`/`npm install` operations to update dependencies, which completed without error; no automated unit tests were present or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c39c54ec832c84c3e15ee33782ad)