### PR TITLE
Add W3C compliance tests and render spec / caniuse metadata in UI

### DIFF
--- a/public/tests/css-grid.js
+++ b/public/tests/css-grid.js
@@ -1,0 +1,10 @@
+function main() {
+    if (typeof CSS !== "undefined" && typeof CSS.supports === "function") {
+        if (CSS.supports("display", "grid")) {
+            return [0, "Test passed."];
+        }
+        return [2, "Test failed. CSS Grid is not supported."];
+    }
+
+    return [4, "Unknown test result. CSS.supports is unavailable."];
+}

--- a/public/tests/fetch.js
+++ b/public/tests/fetch.js
@@ -1,0 +1,7 @@
+function main() {
+    if (typeof fetch === "function") {
+        return [0, "Test passed."];
+    }
+
+    return [2, "Test failed. fetch is not available."];
+}

--- a/public/tests/service-workers.js
+++ b/public/tests/service-workers.js
@@ -1,0 +1,7 @@
+function main() {
+    if ("serviceWorker" in navigator) {
+        return [0, "Test passed."];
+    }
+
+    return [2, "Test failed. Service workers are not supported."];
+}

--- a/public/tests/web-crypto.js
+++ b/public/tests/web-crypto.js
@@ -1,0 +1,11 @@
+function main() {
+    if (typeof crypto === "undefined") {
+        return [2, "Test failed. crypto is undefined."];
+    }
+
+    if (crypto.subtle && typeof crypto.subtle.digest === "function") {
+        return [0, "Test passed."];
+    }
+
+    return [1, "Test partially passed. crypto is available but SubtleCrypto is missing."];
+}

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -21,17 +21,40 @@ const getBrowserName = () => {
       return browser;
 }
 
+const getCaniuseStatus = (featureId: string, browserName: string, browserVersion: string | null) => {
+    if (!featureId || !browserVersion || browserName === 'unknown') {
+        return 'Unknown';
+    }
+
+    const supportData = caniuse.getSupport(featureId);
+    const browserSupport = supportData[browserName];
+    if (browserSupport && browserSupport[browserVersion]) {
+        const status = browserSupport[browserVersion];
+        if (status.startsWith('y')) {
+            return 'Supported';
+        }
+        if (status.startsWith('a')) {
+            return 'Partial';
+        }
+        if (status.startsWith('n')) {
+            return 'Unsupported';
+        }
+        return 'Unknown';
+    }
+
+    return caniuse.isSupported(featureId, `${browserName} ${browserVersion}`) ? 'Supported' : 'Unsupported';
+}
+
 var useragent = navigator.userAgent;
 document.getElementById('useragent')!.innerHTML = useragent;
 var latestStableBrowsers = caniuse.getLatestStableBrowsers();
-(latestStableBrowsers).forEach((browser) => {
-    // var browserName = browser.split(' ')[0];
-    var browserVersion = browser.split(' ')[1];
-    var browserNameElement = document.getElementById("latestBrowser");
-    if (browserNameElement) {
-        browserNameElement.innerHTML = browserVersion;
-    }
-});
+const browserName = getBrowserName();
+const latestStableBrowser = latestStableBrowsers.find((browser) => browser.startsWith(`${browserName} `)) ?? null;
+const latestStableVersion = latestStableBrowser ? latestStableBrowser.split(' ')[1] : null;
+const browserNameElement = document.getElementById("latestBrowser");
+if (browserNameElement) {
+    browserNameElement.innerHTML = latestStableVersion ?? 'unknown';
+}
 
 
 
@@ -65,7 +88,20 @@ tests.forEach((test) => {
             element.classList.add('unknown');
         }
 
-        element.innerHTML = `${test.name} - ${result_text[1]}`;
+        const caniuseStatus = getCaniuseStatus(test.featureId, browserName, latestStableVersion);
+        const specLink = test.specUrl ? `<a href="${test.specUrl}" target="_blank" rel="noreferrer">Spec</a>` : 'Spec: N/A';
+        const wptLink = test.wptRef ? `<a href="https://wpt.fyi/results/${test.wptRef}" target="_blank" rel="noreferrer">WPT</a>` : 'WPT: N/A';
+
+        element.innerHTML = `
+            <div class="test-name">${test.name} - ${result_text[1]}</div>
+            <div class="test-meta">
+                ${specLink}
+                <span class="separator">|</span>
+                ${wptLink}
+                <span class="separator">|</span>
+                <span class="caniuse-status">Can I use: ${caniuseStatus}</span>
+            </div>
+        `;
 
         document.querySelector('.tests')!.appendChild(element);
     })

--- a/src/ts/tests.ts
+++ b/src/ts/tests.ts
@@ -13,12 +13,50 @@ const tests = [
         name: "Cookies",
         test: "/tests/cookies.js",
         points: 50,
+        featureId: "cookies",
+        specUrl: "https://www.rfc-editor.org/rfc/rfc6265",
+        wptRef: "cookies/",
     },
     {
         name: "BigInt",
         test: "/tests/bigint.js",
         points: 50,
-    }
+        featureId: "bigint",
+        specUrl: "https://tc39.es/ecma262/#sec-bigint-objects",
+        wptRef: "js/bigint/",
+    },
+    {
+        name: "Web Crypto",
+        test: "/tests/web-crypto.js",
+        points: 60,
+        featureId: "cryptography",
+        specUrl: "https://www.w3.org/TR/WebCryptoAPI/",
+        wptRef: "WebCryptoAPI/",
+    },
+    {
+        name: "Fetch API",
+        test: "/tests/fetch.js",
+        points: 60,
+        featureId: "fetch",
+        specUrl: "https://fetch.spec.whatwg.org/",
+        wptRef: "fetch/api/",
+    },
+    {
+        name: "CSS Grid",
+        test: "/tests/css-grid.js",
+        points: 60,
+        featureId: "css-grid",
+        specUrl: "https://www.w3.org/TR/css-grid-1/",
+        wptRef: "css/css-grid/",
+    },
+    {
+        name: "Service Workers",
+        test: "/tests/service-workers.js",
+        points: 60,
+        featureId: "serviceworkers",
+        specUrl: "https://www.w3.org/TR/service-workers/",
+        wptRef: "service-workers/",
+    },
 ]
 
 export { tests };


### PR DESCRIPTION
### Motivation
- Expand the test catalog with W3C/core-platform checks and attach external metadata so each test can be compared to caniuse and WPT data.
- Surface authoritative references and compatibility status in the UI to make results more actionable for reviewers.

### Description
- Extended test entries in `src/ts/tests.ts` to include `featureId`, `specUrl`, and `wptRef` for each test.
- Added new runtime checks under `public/tests/` for `web-crypto.js`, `fetch.js`, `css-grid.js`, and `service-workers.js` to cover additional core features.
- Updated `src/ts/main.ts` to determine the latest stable browser version, added `getCaniuseStatus` to query `caniuse-api`, and rendered spec links, WPT links, and Can I Use status alongside each test result.

### Testing
- Ran `npm run dev` which started the Vite dev server successfully and served the app at `http://localhost:4173/`.
- Executed a Playwright script that loaded the served page and produced a screenshot artifact (`artifacts/compliance-tests.png`), and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c39d5c54832caa879f28ebba6e5f)