### PR TITLE
Enhance browser feature coverage and UI summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,19 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Does my browser support...</title>
-
   </head>
   <body>
-    <nav>
-
-    </nav>
     <main>
       <h1>Does your browser support...</h1>
-      <span>Your useragent: <span id="useragent"></span></span>
-      <br />
-      <span>The latest version of your browser is <span id="latestBrowser"></span></span>
-      <ul class="tests">
-      </ul>
+      <div class="browser-meta">
+        <div><strong>User agent:</strong> <span id="useragent"></span></div>
+        <div><strong>Detected browser:</strong> <span id="detectedBrowser"></span></div>
+        <div><strong>Latest stable version:</strong> <span id="latestBrowser"></span></div>
+      </div>
+      <div id="summary" class="summary"></div>
+      <ul class="tests"></ul>
     </main>
     <script type="module" src="/src/ts/main.ts"></script>
   </body>

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -4,6 +4,28 @@ main {
     h1 {
         text-align: center;
     }
+
+    .browser-meta {
+        display: grid;
+        gap: 0.35em;
+        margin-bottom: 1em;
+    }
+
+    .summary {
+        margin-bottom: 1.2em;
+        padding: 0.75em 1em;
+        border-radius: 0.5em;
+        background: #f1f3f5;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4em;
+        align-items: center;
+    }
+
+    .separator {
+        opacity: 0.6;
+    }
+
     ul.tests {
         list-style-type: none;
         padding: 0;

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -1,25 +1,19 @@
 import '../scss/index.scss';
 import { tests } from './tests';
 import type { TestResult } from './tests/types';
-import caniuse from 'caniuse-api';
+import { agents, feature, features } from 'caniuse-lite/dist/unpacker';
 
-const getBrowserName = () => {
-    const browserInfo = navigator.userAgent;
-    let browser;
-    if (browserInfo.includes('Opera') || browserInfo.includes('Opr')) {
-        browser = 'opera';
-    } else if (browserInfo.includes('Edg')) {
-        browser = 'edge';
-    } else if (browserInfo.includes('Chrome')) {
-        browser = 'chrome';
-    } else if (browserInfo.includes('Safari')) {
-        browser = 'safari';
-    } else if (browserInfo.includes('Firefox')) {
-        browser = 'firefox';
-    } else {
-        browser = 'unknown';
-    }
-    return browser;
+type BrowserId = 'chrome' | 'firefox' | 'safari' | 'edge' | 'opera' | 'unknown';
+
+type SupportStatus = 'full' | 'partial' | 'none';
+
+type ScoreBreakdown = {
+    totalPoints: number;
+    earnedPoints: number;
+    passed: number;
+    partial: number;
+    failed: number;
+    unknown: number;
 };
 
 const getStatusClass = (result: TestResult) => {
@@ -34,15 +28,6 @@ const getStatusClass = (result: TestResult) => {
     }
     return 'unknown';
 };
-
-const getCaniuseStatus = (feature: string, browserQuery: string | null) => {
-    if (!browserQuery || browserQuery === 'unknown') {
-        return 'Unknown';
-    }
-import { agents, feature, features } from 'caniuse-lite/dist/unpacker';
-
-type BrowserId = 'chrome' | 'firefox' | 'safari' | 'edge' | 'opera' | 'unknown';
-type SupportStatus = 'full' | 'partial' | 'none';
 
 const parseVersionNumber = (value?: string) => {
     if (!value) {
@@ -169,72 +154,62 @@ const getSupportMessage = (featureKey: string, browserId: BrowserId, version: nu
     };
 };
 
-const userAgent = navigator.userAgent;
-const { browserId, version } = parseUserAgent(userAgent);
-document.getElementById('useragent')!.innerHTML = userAgent;
-const latestStableVersion = getLatestStableVersion(browserId);
-const browserNameElement = document.getElementById('latestBrowser');
-if (browserNameElement) {
-    browserNameElement.innerHTML = latestStableVersion ?? 'Unknown';
-const getCaniuseStatus = (featureId: string, browserName: string, browserVersion: string | null) => {
-    if (!featureId || !browserVersion || browserName === 'unknown') {
-        return 'Unknown';
+const scoreTestResult = (result: TestResult, points: number) => {
+    if (result.code === 0) {
+        return points;
     }
-
-    const supportData = caniuse.getSupport(featureId);
-    const browserSupport = supportData[browserName];
-    if (browserSupport && browserSupport[browserVersion]) {
-        const status = browserSupport[browserVersion];
-        if (status.startsWith('y')) {
-            return 'Supported';
-        }
-        if (status.startsWith('a')) {
-            return 'Partial';
-        }
-        if (status.startsWith('n')) {
-            return 'Unsupported';
-        }
-        return 'Unknown';
+    if (result.code === 1 || result.code === 3) {
+        return Math.round(points * 0.5);
     }
-
-    return caniuse.isSupported(featureId, `${browserName} ${browserVersion}`) ? 'Supported' : 'Unsupported';
-}
-
-var useragent = navigator.userAgent;
-document.getElementById('useragent')!.innerHTML = useragent;
-var latestStableBrowsers = caniuse.getLatestStableBrowsers();
-const browserName = getBrowserName();
-const latestStableBrowser = latestStableBrowsers.find((browser) => browser.startsWith(`${browserName} `)) ?? null;
-const latestStableVersion = latestStableBrowser ? latestStableBrowser.split(' ')[1] : null;
-const browserNameElement = document.getElementById("latestBrowser");
-if (browserNameElement) {
-    browserNameElement.innerHTML = latestStableVersion ?? 'unknown';
-}
-
-    try {
-        return caniuse.isSupported(feature, browserQuery) ? 'Supported' : 'Not supported';
-    } catch (error) {
-        console.error(error);
-        return 'Unknown';
-    }
+    return 0;
 };
 
-const browserName = getBrowserName();
-const useragent = navigator.userAgent;
-const latestStableBrowsers = caniuse.getLatestStableBrowsers();
-const browserEntry = latestStableBrowsers.find((browser) => browser.startsWith(`${browserName} `)) ?? null;
-const browserVersion = browserEntry ? browserEntry.split(' ')[1] : 'unknown';
-const browserQuery = browserEntry ? `${browserName} ${browserVersion}` : null;
+const updateSummary = (summary: ScoreBreakdown) => {
+    const summaryElement = document.getElementById('summary');
+    if (!summaryElement) {
+        return;
+    }
+
+    summaryElement.innerHTML = `
+        <strong>Score:</strong> ${summary.earnedPoints} / ${summary.totalPoints}
+        <span class="separator">•</span>
+        <strong>Passed:</strong> ${summary.passed}
+        <span class="separator">•</span>
+        <strong>Partial:</strong> ${summary.partial}
+        <span class="separator">•</span>
+        <strong>Failed:</strong> ${summary.failed}
+        <span class="separator">•</span>
+        <strong>Unknown:</strong> ${summary.unknown}
+    `;
+};
+
+const userAgent = navigator.userAgent;
+const { browserId, version } = parseUserAgent(userAgent);
+const latestStableVersion = getLatestStableVersion(browserId);
 
 const userAgentElement = document.getElementById('useragent');
 if (userAgentElement) {
-    userAgentElement.textContent = useragent;
+    userAgentElement.textContent = userAgent;
 }
 
 const browserNameElement = document.getElementById('latestBrowser');
 if (browserNameElement) {
-    browserNameElement.textContent = browserVersion;
+    browserNameElement.textContent = latestStableVersion ?? 'Unknown';
 }
+
+const detectedBrowserElement = document.getElementById('detectedBrowser');
+if (detectedBrowserElement) {
+    detectedBrowserElement.textContent = browserId === 'unknown' ? 'Unknown' : `${browserId} ${version}`;
+}
+
+const summary: ScoreBreakdown = {
+    totalPoints: 0,
+    earnedPoints: 0,
+    passed: 0,
+    partial: 0,
+    failed: 0,
+    unknown: 0,
+};
 
 tests.forEach((test) => {
     const result = test.run();
@@ -270,66 +245,27 @@ tests.forEach((test) => {
 
     const caniuseItem = document.createElement('div');
     caniuseItem.classList.add('test-meta-item');
-    const caniuseStatus = getCaniuseStatus(test.caniuseFeature, browserQuery);
-    caniuseItem.textContent = `Can I use (${test.caniuseFeature}) for ${browserQuery ?? 'unknown'}: ${caniuseStatus}`;
+    const caniuseStatus = getSupportMessage(test.caniuseFeature, browserId, version);
+    caniuseItem.textContent = caniuseStatus.message;
 
     meta.appendChild(specItem);
     meta.appendChild(caniuseItem);
     element.appendChild(meta);
 
     document.querySelector('.tests')!.appendChild(element);
-    fetch(test.test).then((response) => {
-        return response.text()
-    })
-    .then((text) => {
-        console.log(text);
-        let result_text = Function("const to_ret =  " + text.replace("function main()", "() =>") + "\nreturn to_ret();")();
 
-        console.log(result_text);
-        let result = result_text[0];
+    summary.totalPoints += test.points;
+    summary.earnedPoints += scoreTestResult(result, test.points);
 
-        let element = document.createElement('li');
-        element.id = test.name;
-
-        if (result === 0) {
-            element.classList.add('passed');
-        }
-        else if (result === 1) {
-            element.classList.add('partial');
-        }
-        else if (result === 2) {
-            element.classList.add('failed');
-        }
-        else if (result === 3) {
-            element.classList.add('partial');
-        }
-        else {
-            element.classList.add('unknown');
-        }
-
-        const caniuseComparison = test.caniuseFeature
-            ? getSupportMessage(test.caniuseFeature, browserId, version)
-            : { status: 'none', message: 'Caniuse: No feature mapping available.' };
-
-        element.innerHTML = `${test.name} - ${result_text[1]}<br /><small>${caniuseComparison.message}</small>`;
-        const caniuseStatus = getCaniuseStatus(test.featureId, browserName, latestStableVersion);
-        const specLink = test.specUrl ? `<a href="${test.specUrl}" target="_blank" rel="noreferrer">Spec</a>` : 'Spec: N/A';
-        const wptLink = test.wptRef ? `<a href="https://wpt.fyi/results/${test.wptRef}" target="_blank" rel="noreferrer">WPT</a>` : 'WPT: N/A';
-
-        element.innerHTML = `
-            <div class="test-name">${test.name} - ${result_text[1]}</div>
-            <div class="test-meta">
-                ${specLink}
-                <span class="separator">|</span>
-                ${wptLink}
-                <span class="separator">|</span>
-                <span class="caniuse-status">Can I use: ${caniuseStatus}</span>
-            </div>
-        `;
-
-        document.querySelector('.tests')!.appendChild(element);
-    })
-    .catch((error) => {
-        console.error(error);
-    });
+    if (result.code === 0) {
+        summary.passed += 1;
+    } else if (result.code === 1 || result.code === 3) {
+        summary.partial += 1;
+    } else if (result.code === 2) {
+        summary.failed += 1;
+    } else {
+        summary.unknown += 1;
+    }
 });
+
+updateSummary(summary);

--- a/src/ts/tests.ts
+++ b/src/ts/tests.ts
@@ -11,6 +11,14 @@ They return 4 if unknown.
 import type { BrowserTest } from './tests/types';
 import runBigIntTest from './tests/bigint';
 import runCookiesTest from './tests/cookies';
+import runCssGridTest from './tests/css-grid';
+import runFetchTest from './tests/fetch';
+import runServiceWorkerTest from './tests/service-worker';
+import runWebAssemblyTest from './tests/webassembly';
+import runWebAudioTest from './tests/web-audio';
+import runWebCryptoTest from './tests/web-crypto';
+import runWebGl2Test from './tests/webgl2';
+import runWebRtcTest from './tests/webrtc';
 
 const tests: BrowserTest[] = [
     {
@@ -18,14 +26,10 @@ const tests: BrowserTest[] = [
         points: 50,
         run: runCookiesTest,
         spec: {
-            title: 'W3C HTML 5.2: document.cookie',
-            url: 'https://www.w3.org/TR/html52/semantics-scripting.html#dom-document-cookie',
+            title: 'W3C HTML: document.cookie',
+            url: 'https://html.spec.whatwg.org/multipage/webstorage.html#dom-document-cookie',
         },
         caniuseFeature: 'cookie-store-api',
-        caniuseFeature: "cookie-store-api",
-        featureId: "cookies",
-        specUrl: "https://www.rfc-editor.org/rfc/rfc6265",
-        wptRef: "cookies/",
     },
     {
         name: 'BigInt',
@@ -37,45 +41,86 @@ const tests: BrowserTest[] = [
         },
         caniuseFeature: 'bigint',
     },
+    {
+        name: 'Web Crypto',
+        points: 60,
+        run: runWebCryptoTest,
+        spec: {
+            title: 'W3C Web Crypto API',
+            url: 'https://www.w3.org/TR/WebCryptoAPI/',
+        },
+        caniuseFeature: 'cryptography',
+    },
+    {
+        name: 'Fetch API',
+        points: 60,
+        run: runFetchTest,
+        spec: {
+            title: 'Fetch Standard',
+            url: 'https://fetch.spec.whatwg.org/',
+        },
+        caniuseFeature: 'fetch',
+    },
+    {
+        name: 'CSS Grid',
+        points: 60,
+        run: runCssGridTest,
+        spec: {
+            title: 'W3C CSS Grid Layout Module',
+            url: 'https://www.w3.org/TR/css-grid-1/',
+        },
+        caniuseFeature: 'css-grid',
+    },
+    {
+        name: 'Service Workers',
+        points: 60,
+        run: runServiceWorkerTest,
+        spec: {
+            title: 'W3C Service Workers',
+            url: 'https://www.w3.org/TR/service-workers/',
+        },
+        caniuseFeature: 'serviceworkers',
+    },
+    {
+        name: 'WebAssembly',
+        points: 60,
+        run: runWebAssemblyTest,
+        spec: {
+            title: 'W3C WebAssembly Core Specification',
+            url: 'https://www.w3.org/TR/wasm-core-1/',
+        },
+        caniuseFeature: 'wasm',
+    },
+    {
+        name: 'Web Audio',
+        points: 50,
+        run: runWebAudioTest,
+        spec: {
+            title: 'W3C Web Audio API',
+            url: 'https://www.w3.org/TR/webaudio/',
+        },
+        caniuseFeature: 'audio-api',
+    },
+    {
+        name: 'WebGL 2',
+        points: 50,
+        run: runWebGl2Test,
+        spec: {
+            title: 'Khronos WebGL 2.0',
+            url: 'https://www.khronos.org/registry/webgl/specs/latest/2.0/',
+        },
+        caniuseFeature: 'webgl2',
+    },
+    {
+        name: 'WebRTC',
+        points: 60,
+        run: runWebRtcTest,
+        spec: {
+            title: 'W3C WebRTC 1.0',
+            url: 'https://www.w3.org/TR/webrtc/',
+        },
+        caniuseFeature: 'rtcpeerconnection',
+    },
 ];
-        caniuseFeature: "bigint",
-    }
-        featureId: "bigint",
-        specUrl: "https://tc39.es/ecma262/#sec-bigint-objects",
-        wptRef: "js/bigint/",
-    },
-    {
-        name: "Web Crypto",
-        test: "/tests/web-crypto.js",
-        points: 60,
-        featureId: "cryptography",
-        specUrl: "https://www.w3.org/TR/WebCryptoAPI/",
-        wptRef: "WebCryptoAPI/",
-    },
-    {
-        name: "Fetch API",
-        test: "/tests/fetch.js",
-        points: 60,
-        featureId: "fetch",
-        specUrl: "https://fetch.spec.whatwg.org/",
-        wptRef: "fetch/api/",
-    },
-    {
-        name: "CSS Grid",
-        test: "/tests/css-grid.js",
-        points: 60,
-        featureId: "css-grid",
-        specUrl: "https://www.w3.org/TR/css-grid-1/",
-        wptRef: "css/css-grid/",
-    },
-    {
-        name: "Service Workers",
-        test: "/tests/service-workers.js",
-        points: 60,
-        featureId: "serviceworkers",
-        specUrl: "https://www.w3.org/TR/service-workers/",
-        wptRef: "service-workers/",
-    },
-]
 
 export { tests };

--- a/src/ts/tests/css-grid.ts
+++ b/src/ts/tests/css-grid.ts
@@ -1,0 +1,25 @@
+import type { TestResult } from './types';
+
+const runCssGridTest = (): TestResult => {
+    if (typeof CSS !== 'undefined' && typeof CSS.supports === 'function') {
+        if (CSS.supports('display', 'grid')) {
+            return {
+                code: 0,
+                message: 'CSS Grid is supported.',
+            };
+        }
+        return {
+            code: 2,
+            message: 'CSS Grid is not supported.',
+            details: 'CSS.supports("display", "grid") returned false.',
+        };
+    }
+
+    return {
+        code: 4,
+        message: 'Unable to detect CSS Grid support.',
+        details: 'CSS.supports API is not available.',
+    };
+};
+
+export default runCssGridTest;

--- a/src/ts/tests/fetch.ts
+++ b/src/ts/tests/fetch.ts
@@ -1,0 +1,30 @@
+import type { TestResult } from './types';
+
+const runFetchTest = (): TestResult => {
+    const hasFetch = typeof fetch === 'function';
+    const hasRequest = typeof Request !== 'undefined';
+    const hasResponse = typeof Response !== 'undefined';
+    const hasHeaders = typeof Headers !== 'undefined';
+
+    if (hasFetch && hasRequest && hasResponse && hasHeaders) {
+        return {
+            code: 0,
+            message: 'Fetch API is fully supported.',
+        };
+    }
+
+    if (hasFetch) {
+        return {
+            code: 1,
+            message: 'Fetch API is partially supported.',
+            details: 'Fetch is available but Request/Response/Headers are missing.',
+        };
+    }
+
+    return {
+        code: 2,
+        message: 'Fetch API is not supported.',
+    };
+};
+
+export default runFetchTest;

--- a/src/ts/tests/service-worker.ts
+++ b/src/ts/tests/service-worker.ts
@@ -1,0 +1,24 @@
+import type { TestResult } from './types';
+
+const runServiceWorkerTest = (): TestResult => {
+    if ('serviceWorker' in navigator) {
+        if (window.isSecureContext) {
+            return {
+                code: 0,
+                message: 'Service Workers are available in a secure context.',
+            };
+        }
+        return {
+            code: 1,
+            message: 'Service Workers require a secure context.',
+            details: 'This page is not running in a secure context.',
+        };
+    }
+
+    return {
+        code: 2,
+        message: 'Service Workers are not supported.',
+    };
+};
+
+export default runServiceWorkerTest;

--- a/src/ts/tests/web-audio.ts
+++ b/src/ts/tests/web-audio.ts
@@ -1,0 +1,19 @@
+import type { TestResult } from './types';
+
+const runWebAudioTest = (): TestResult => {
+    const AudioContextRef = window.AudioContext ?? window.webkitAudioContext;
+
+    if (AudioContextRef) {
+        return {
+            code: 0,
+            message: 'Web Audio API is supported.',
+        };
+    }
+
+    return {
+        code: 2,
+        message: 'Web Audio API is not supported.',
+    };
+};
+
+export default runWebAudioTest;

--- a/src/ts/tests/web-crypto.ts
+++ b/src/ts/tests/web-crypto.ts
@@ -1,0 +1,24 @@
+import type { TestResult } from './types';
+
+const runWebCryptoTest = (): TestResult => {
+    if (window.crypto && window.crypto.subtle) {
+        if (window.isSecureContext) {
+            return {
+                code: 0,
+                message: 'Web Crypto API is supported in a secure context.',
+            };
+        }
+        return {
+            code: 1,
+            message: 'Web Crypto API requires a secure context.',
+            details: 'window.crypto.subtle is present but this page is not secure.',
+        };
+    }
+
+    return {
+        code: 2,
+        message: 'Web Crypto API is not supported.',
+    };
+};
+
+export default runWebCryptoTest;

--- a/src/ts/tests/webassembly.ts
+++ b/src/ts/tests/webassembly.ts
@@ -1,0 +1,24 @@
+import type { TestResult } from './types';
+
+const runWebAssemblyTest = (): TestResult => {
+    if (typeof WebAssembly === 'object') {
+        if (typeof WebAssembly.validate === 'function') {
+            return {
+                code: 0,
+                message: 'WebAssembly is supported.',
+            };
+        }
+        return {
+            code: 1,
+            message: 'WebAssembly is partially supported.',
+            details: 'WebAssembly exists but validation is unavailable.',
+        };
+    }
+
+    return {
+        code: 2,
+        message: 'WebAssembly is not supported.',
+    };
+};
+
+export default runWebAssemblyTest;

--- a/src/ts/tests/webgl2.ts
+++ b/src/ts/tests/webgl2.ts
@@ -1,0 +1,20 @@
+import type { TestResult } from './types';
+
+const runWebGl2Test = (): TestResult => {
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('webgl2');
+
+    if (context) {
+        return {
+            code: 0,
+            message: 'WebGL 2 is supported.',
+        };
+    }
+
+    return {
+        code: 2,
+        message: 'WebGL 2 is not supported.',
+    };
+};
+
+export default runWebGl2Test;

--- a/src/ts/tests/webrtc.ts
+++ b/src/ts/tests/webrtc.ts
@@ -1,0 +1,19 @@
+import type { TestResult } from './types';
+
+const runWebRtcTest = (): TestResult => {
+    const PeerConnectionRef = window.RTCPeerConnection ?? window.webkitRTCPeerConnection ?? window.mozRTCPeerConnection;
+
+    if (PeerConnectionRef) {
+        return {
+            code: 0,
+            message: 'WebRTC RTCPeerConnection is supported.',
+        };
+    }
+
+    return {
+        code: 2,
+        message: 'WebRTC RTCPeerConnection is not supported.',
+    };
+};
+
+export default runWebRtcTest;

--- a/src/ts/vite-env.d.ts
+++ b/src/ts/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+declare global {
+    interface Window {
+        webkitAudioContext?: typeof AudioContext;
+        webkitRTCPeerConnection?: typeof RTCPeerConnection;
+        mozRTCPeerConnection?: typeof RTCPeerConnection;
+    }
+}
+
+export {};


### PR DESCRIPTION
### Motivation
- Broaden the browser capability test suite to cover common W3C/modern platform features and provide clearer, scored results. 
- Replace ad-hoc feature/status logic with a deterministic `caniuse-lite`-based lookup so results can be correlated with published support data. 

### Description
- Reworked the runner in `src/ts/main.ts` to parse the UA, map to `caniuse-lite` `agents|features`, compute scores with `scoreTestResult`, and render a summary block with totals and pass/partial/failed counts. 
- Added concrete capability checks as individual tests under `src/ts/tests/` for `Web Crypto`, `Fetch`, `CSS Grid`, `Service Workers`, `WebAssembly`, `Web Audio`, `WebGL2`, and `WebRTC`, and expanded `src/ts/tests.ts` to include these tests. 
- Updated the UI to show browser metadata and the summary by changing `index.html` and `src/scss/index.scss`. 
- Added runtime type fallbacks in `src/ts/vite-env.d.ts` for vendor-prefixed audio/WebRTC globals and switched to `caniuse-lite/dist/unpacker` for local support messages. 

### Testing
- Started the dev server with `npm run dev` (served at `http://localhost:4173/`) and it started successfully under Vite. 
- Ran a headless Playwright script that loaded `http://127.0.0.1:4173/` and captured a screenshot; the page loaded and the screenshot was produced successfully. 
- No automated unit tests were added for the new checks (no failures reported from the above runs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c6665d2c832cab572adb116bc7f3)