### PR TITLE
Fix caniuse-lite typing errors during build

### DIFF
--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -70,7 +70,8 @@ const getLatestStableVersion = (browserId: BrowserId) => {
     }
 
     const releaseDates = agentData.release_date ?? {};
-    const latestRelease = Object.entries(releaseDates).reduce(
+    const releaseEntries = Object.entries(releaseDates) as [string, number][];
+    const latestRelease = releaseEntries.reduce(
         (latest, [version, releaseDate]) => {
             if (releaseDate > latest.releaseDate) {
                 return { version, releaseDate };
@@ -84,7 +85,7 @@ const getLatestStableVersion = (browserId: BrowserId) => {
         return latestRelease.version;
     }
 
-    const versions = agentData.versions?.filter((entry) => entry) ?? [];
+    const versions = agentData.versions?.filter((entry): entry is string => Boolean(entry)) ?? [];
     return versions.length > 0 ? versions[versions.length - 1] : null;
 };
 

--- a/src/ts/types/caniuse-lite.d.ts
+++ b/src/ts/types/caniuse-lite.d.ts
@@ -1,0 +1,14 @@
+declare module 'caniuse-lite/dist/unpacker' {
+    type AgentData = {
+        release_date?: Record<string, number>;
+        versions?: Array<string | null | undefined>;
+    };
+
+    type FeatureData = {
+        stats: Record<string, Record<string, string>>;
+    };
+
+    export const agents: Record<string, AgentData>;
+    export const features: Record<string, unknown>;
+    export function feature(data: unknown): FeatureData;
+}


### PR DESCRIPTION
### Motivation
- The TypeScript build was failing due to missing declarations for `caniuse-lite/dist/unpacker` and incompatible/unknown types when inspecting `agentData.release_date` and `agentData.versions`.
- The project uses `strict` TypeScript settings, so implicit `any` and `unknown` values in `Object.entries`/`reduce` and array filtering needed to be tightened to restore a clean build.

### Description
- Add a local declaration file at `src/ts/types/caniuse-lite.d.ts` that declares `agents`, `features`, and `feature()` for `caniuse-lite/dist/unpacker` to satisfy TypeScript (`TS7016`).
- Narrow the type of `Object.entries(agentData.release_date)` by casting to `([string, number])[]` as `releaseEntries` before calling `reduce` to prevent `unknown`/reduce type errors.
- Add a type-guarding filter `filter((entry): entry is string => Boolean(entry))` for `agentData.versions` to ensure the array is `string[]` when indexed.
- Modified `src/ts/main.ts` to use the new typed variables so the previous `unknown`/implicit `any` errors are resolved.

### Testing
- Ran `npm run build`, which completed successfully (produced the production build without TypeScript errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c801fba8832cb7479ca8f4310243)