### PR TITLE
Add wrangler.jsonc to configure Cloudflare Worker entrypoint and assets

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "name": "browser-test",
+  "compatibility_date": "2026-01-21",
+  "main": ".svelte-kit/cloudflare/_worker.js",
+  "assets": {
+    "directory": ".svelte-kit/cloudflare/assets"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a Wrangler configuration so Cloudflare Workers deployment can locate the worker entrypoint and the directory of static assets.

### Description
- Add `wrangler.jsonc` that sets `name` to `browser-test`, `compatibility_date` to `2026-01-21`, `main` to `.svelte-kit/cloudflare/_worker.js`, and `assets.directory` to `.svelte-kit/cloudflare/assets`.

### Testing
- Existing CI run showed `npm run build` completed successfully but `npx wrangler deploy` previously failed with `Missing entry-point to Worker script or to assets directory`, and no automated tests were executed after adding the config.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970d4050f3c832c8475f2ab24e87887)