### PR TITLE
Use wrangler.toml for Cloudflare deploy (point assets to .svelte-kit/cloudflare)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,6 @@
+name = "browser-test"
+compatibility_date = "2026-01-21"
+main = ".svelte-kit/cloudflare/_worker.js"
+
+[assets]
+directory = ".svelte-kit/cloudflare"


### PR DESCRIPTION
### Motivation
- Ensure Wrangler can locate the worker entrypoint and the static assets produced by `@sveltejs/adapter-cloudflare` so deployments do not fail due to a missing assets directory.

### Description
- Remove `wrangler.jsonc` and add `wrangler.toml` with `name = "browser-test"`, `compatibility_date = "2026-01-21"`, `main = ".svelte-kit/cloudflare/_worker.js"`, and `[assets] directory = ".svelte-kit/cloudflare"` to align Wrangler config with the adapter output.

### Testing
- Ran `npm run build` which completed successfully; `npx wrangler deploy` had previously failed with a missing `assets.directory` and was not re-run after this config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970d4050f3c832c8475f2ab24e87887)